### PR TITLE
Disable SendChatMessage outside instances/raids

### DIFF
--- a/modules/interrupted.lua
+++ b/modules/interrupted.lua
@@ -11,8 +11,10 @@ local function OnEvent(self, event)
 	local timestamp, subevent, hideCaster, sourceGUID, sourceName, sourceFlags, sourceRaidFlags, destGUID, destName, destFlags, destRaidFlags, spellID, spellName, spellSchool, extraSpellID, extraSpellName, school, resisted, blocked, absorbed, critial, glancing, crushing, isOffHand = CombatLogGetCurrentEventInfo()
 
 	if (subevent ~= 'SPELL_INTERRUPT') then return end
+	
+	local inInstance, instanceType = IsInInstance()
 
-	if (UnitExists(sourceName) and UnitIsUnit(sourceName, 'player')) then
+	if (UnitExists(sourceName) and UnitIsUnit(sourceName, 'player') and inInstance and (instanceType == "party" or instanceType == "raid")) then
 		SendChatMessage(UnitName("player")..' interrupted ' .. GetSpellLink(extraSpellID), channel)
 	end
 end


### PR DESCRIPTION
Interrupts in open world caused LUA errors.
Disable SendChatMessage outside instances and raids due to Blizzard patch 8.2.5 API changes. Info: https://wow.gamepedia.com/Patch_8.2.5/API_changes.